### PR TITLE
Transaction timstamp update + TransactionPostModel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,9 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
 
@@ -1191,6 +1193,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pong-transaction-service"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "futures",
  "mongodb",
  "rocket",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ serde = "1.0.202"
 futures = "0.3.30"
 tokio = { version = "1.37.0", features = ["full"]}
 mongodb = { version = "2.8.2", features = ["tokio-runtime"]}
+chrono = "0.4.38"

--- a/http-tests/createTransactionTest.http
+++ b/http-tests/createTransactionTest.http
@@ -3,11 +3,9 @@ POST http://127.0.0.1:8000/createTransaction
 Content-Type: application/json
 
 {
-  "id": null,
   "sender_id": "60d5f67e8a317f2d3c4d8f90",
   "receiver_id": "60d5f67e8a317f2d3c4d8f91",
   "amount": 20,
-  "time_stamp": "today",
   "description": "User earned their daily login reward."
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ async fn post_test_transaction() -> String {
         ObjectId::new(),
         ObjectId::new(),
         200,
+        "Now".to_string(),
         "fake description".to_string()
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 mod transaction;
 mod transaction_service;
+mod transaction_post_model;
 
 #[macro_use] extern crate rocket;
 
 use mongodb::bson::oid::ObjectId;
 use rocket::serde::json::Json;
 use crate::transaction::Transaction;
+use crate::transaction_post_model::TransactionPostModel;
 use crate::transaction_service::TransactionService;
 
 
@@ -34,7 +36,6 @@ async fn post_test_transaction() -> String {
         ObjectId::new(),
         ObjectId::new(),
         200,
-        "now".to_string(),
         "fake description".to_string()
     );
 
@@ -44,13 +45,14 @@ async fn post_test_transaction() -> String {
 
 
 #[post("/createTransaction", data = "<transaction>")]
-async fn post_transaction(transaction: Json<Transaction>) -> String {
+async fn post_transaction(transaction: Json<TransactionPostModel>) -> String {
     let service = TransactionService::new().expect("Failed to get mongodb uri.");
     
-    let mut parsed_transaction = transaction.into_inner();
-    parsed_transaction.id = None;
-    let new_id = service.post_transaction(parsed_transaction).await.unwrap();
+    let transaction_post_model = transaction.into_inner();
+    let parsed_transaction = transaction_post_model.to_transaction();
     
+    let new_id = service.post_transaction(parsed_transaction).await
+        .expect("Failed to post transaction based on given data.");
     format!("New transaction id: {}", new_id)
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,5 @@
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
-use chrono::prelude::*;
 
 
 
@@ -21,11 +20,9 @@ impl Transaction {
         sender_id: ObjectId,
         receiver_id: ObjectId,
         amount: i64,
+        time_stamp: String,
         description: String
     ) -> Self {
-        let utc: DateTime<Utc> = Utc::now();
-        let time_stamp = utc.to_string();
-
         Self { id, sender_id, receiver_id, amount, time_stamp, description }
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,5 +1,6 @@
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
+use chrono::prelude::*;
 
 
 
@@ -20,9 +21,11 @@ impl Transaction {
         sender_id: ObjectId,
         receiver_id: ObjectId,
         amount: i64,
-        time_stamp: String,
         description: String
     ) -> Self {
+        let utc: DateTime<Utc> = Utc::now();
+        let time_stamp = utc.to_string();
+
         Self { id, sender_id, receiver_id, amount, time_stamp, description }
     }
 }

--- a/src/transaction_post_model.rs
+++ b/src/transaction_post_model.rs
@@ -1,0 +1,23 @@
+use mongodb::bson::oid::ObjectId;
+use serde::{Deserialize, Serialize};
+use crate::transaction::Transaction;
+
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TransactionPostModel {
+    pub sender_id: ObjectId,
+    pub receiver_id: ObjectId,
+    pub amount: i64,
+    pub description: String,
+}
+impl TransactionPostModel {
+    pub fn to_transaction(&self) -> Transaction {
+        Transaction::new(
+            None,
+            self.sender_id,
+            self.receiver_id,
+            self.amount,
+            self.description.clone(),
+        )
+    }
+}

--- a/src/transaction_post_model.rs
+++ b/src/transaction_post_model.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
 use crate::transaction::Transaction;
@@ -12,11 +13,15 @@ pub struct TransactionPostModel {
 }
 impl TransactionPostModel {
     pub fn to_transaction(&self) -> Transaction {
+        let utc: DateTime<Utc> = Utc::now();
+        let time_stamp = utc.to_string();
+        
         Transaction::new(
             None,
             self.sender_id,
             self.receiver_id,
             self.amount,
+            time_stamp,
             self.description.clone(),
         )
     }


### PR DESCRIPTION
Transaction timestamps no longer just hold mock data. Also added a 'TransactionPostModel' to allow for further sanitization of input data on post requests.

Now also made it so the timestamp is generated when creating a Transaction from TransactionPostModel.